### PR TITLE
update URL of TiDB Cloud free trial 

### DIFF
--- a/PingExpress_DemoCorp/workshop.md
+++ b/PingExpress_DemoCorp/workshop.md
@@ -16,7 +16,7 @@ You should have the following software and packages installed:
 Note: It is recommended to use pip3 to install packages, such as SQLAlchemy. We also suggest NOT to use the Mac application version for Metabase. It is gradually being phased out. We recommend you run Metabase on [Heroku](https://www.metabase.com/docs/latest/operations-guide/running-metabase-on-heroku.html). You may also use the jar version for Metabase.
 
 ## Task 1: Create a TiDB Developer Tier cluster (10 minutes)
-1. If you do not have a TiDB Cloud account, click [here](https://tidbcloud.com/signup) to sign up for an account.
+1. If you do not have a TiDB Cloud account, click [here](https://tidbcloud.com/free-trial) to sign up for an account.
 2. [Log in](https://tidbcloud.com/) to your TiDB Cloud account.
 3. Click **Create a Cluster**. 
 4. Click **Developer Tier**.


### PR DESCRIPTION
Since we have a new website for quick signup, it is better than we replace https://tidbcloud.com/signup with https://tidbcloud.com/free-trial in the URL.